### PR TITLE
Fix initCreate

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,13 +85,12 @@ func initCreate() error {
 		setupLog.Error(err, "Failure to read kubeconfig.")
 	}
 
-	var clusterDetector = &replicatev1.ClusterDetector{}
-
-	clusterDetector.SetNamespace("resource-replicator-system")
-
 	ctx := context.Background()
 
 	for _, t := range targetCluster {
+		clusterDetector := &replicatev1.ClusterDetector{}
+		clusterDetector.SetNamespace("resource-replicator-system")
+
 		clusterDetector.SetName(t.ContextName)
 		/////////////////////////////
 		// Create ClusterDetector


### PR DESCRIPTION
あんまりControllerの実装方針わかってないですがこれじゃダメっすか？
一応エラー解消されて`clusterdetectors`ってリソースは`initCreate()`の中で`kubeconfig`の`context`分作られたように見えます。

`clusterdetectors`が作成されたことの確認
```
$ k -n resource-replicator-system get clusterdetectors 
NAME                     CONTEXT                  CLUSTER    USER            CLUSTERSTATUS
cluster1admin-cluster1   cluster1admin-cluster1   cluster1   cluster1admin   Running
cluster2admin-cluster2   cluster2admin-cluster2   cluster2   cluster2admin   Running
cluster3admin-cluster3   cluster3admin-cluster3   cluster3   cluster3admin   Running
kindkind                 kindkind                 kindkind   kindkind 
```

Controllerログ
```
$ make run                                                                                     (kind-kind/default)
mkdir -p /home/ubuntu-user/go/resource-replicator/bin
test -s /home/ubuntu-user/go/resource-replicator/bin/controller-gen && /home/ubuntu-user/go/resource-replicator/bin/controller-gen --version | grep -q v0.11.1 || \
GOBIN=/home/ubuntu-user/go/resource-replicator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1
/home/ubuntu-user/go/resource-replicator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/ubuntu-user/go/resource-replicator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go run ./main.go
2023-02-04T02:14:49+09:00	INFO	setup	ClusterDetector created

ok
2023-02-04T02:14:49+09:00	INFO	setup	[ClusterDetector: cluster1admin-cluster1] Complete status update
2023-02-04T02:14:49+09:00	INFO	setup	ClusterDetector created

ok
2023-02-04T02:14:49+09:00	INFO	setup	[ClusterDetector: cluster2admin-cluster2] Complete status update
2023-02-04T02:14:49+09:00	INFO	setup	ClusterDetector created

ok
2023-02-04T02:14:49+09:00	INFO	setup	[ClusterDetector: cluster3admin-cluster3] Complete status update
2023-02-04T02:14:49+09:00	INFO	setup	ClusterDetector created

2023-02-04T02:14:49+09:00	INFO	setup	[ClusterDetector: kindkind] Complete status update
2023-02-04T02:14:49+09:00	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
2023-02-04T02:14:49+09:00	INFO	setup	starting manager
2023-02-04T02:14:49+09:00	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-02-04T02:14:49+09:00	INFO	Starting server	{"kind": "health probe", "addr": "[::]:8081"}
2023-02-04T02:14:49+09:00	INFO	Starting EventSource	{"controller": "clusterdetector", "controllerGroup": "replicate.jnytnai0613.github.io", "controllerKind": "ClusterDetector", "source": "kind source: *v1.ClusterDetector"}
2023-02-04T02:14:49+09:00	INFO	Starting Controller	{"controller": "clusterdetector", "controllerGroup": "replicate.jnytnai0613.github.io", "controllerKind": "ClusterDetector"}
2023-02-04T02:14:49+09:00	INFO	Starting workers	{"controller": "clusterdetector", "controllerGroup": "replicate.jnytnai0613.github.io", "controllerKind": "ClusterDetector", "worker count": 1}
```